### PR TITLE
fix: allow scope to be upper case

### DIFF
--- a/angularcommit/angular.go
+++ b/angularcommit/angular.go
@@ -155,7 +155,7 @@ func parseAngularHead(text string) *Change {
 		return &Change{
 			isAngular:  true,
 			CommitType: strings.ToLower(strings.Trim(match[1], " \t\n")),
-			Scope:      strings.ToLower(strings.Trim(match[2], " \t\n")),
+			Scope:      strings.Trim(match[2], " \t\n"),
 			Subject:    strings.Trim(match[3], " \t\n"),
 		}
 	}

--- a/angularcommit/angular_test.go
+++ b/angularcommit/angular_test.go
@@ -15,7 +15,7 @@ func TestAngularHead(t *testing.T) {
 	}{
 		{"fix(testing): angular head", true, "fix", "testing", "angular head"},
 		{"fix(testing): angular head  ", true, "fix", "testing", "angular head"},
-		{"Fix(Testing): Angular head  ", true, "fix", "testing", "Angular head"},
+		{"Fix(Testing): Angular head  ", true, "fix", "Testing", "Angular head"},
 		{" fix (testing): angular head", true, "fix", "testing", "angular head"},
 		{" fix ( testing ): angular head", true, "fix", "testing", "angular head"},
 		{"fix: angular head", true, "fix", "", "angular head"},


### PR DESCRIPTION
Uppercase scopes are needed if you want to use the scope as jira ticket number. Gitlab needs uppercase ticket names to connect them to jira.